### PR TITLE
Build minimal Docker image that runs without root priviledges

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*
+!*.go
+!go.mod
+!go.sum

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+ARG BASE=alpine:latest
 ARG GOOS=linux
 ARG GOARCH=amd64
  
@@ -20,9 +21,7 @@ RUN CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} GO111MODULE=on go build -a -o bi
 
 RUN mkdir data
 
-# Use distroless as minimal base image
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM $BASE 
 WORKDIR /app
 COPY --from=builder /workspace/bitraft .
 COPY --from=builder --chown=65532:65532 /workspace/data /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,37 @@
+ARG GOOS=linux
+ARG GOARCH=amd64
+ 
+# Build the purge binary
+FROM golang:1.15 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go version.go server.go ./
+
 # Build
-FROM prologic/go-builder:latest AS build
+RUN CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} GO111MODULE=on go build -a -o bitraft
 
-# Runtime
-FROM alpine
+RUN mkdir data
 
-COPY --from=build /src/bitraft /bitraft
+# Use distroless as minimal base image
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /app
+COPY --from=builder /workspace/bitraft .
+COPY --from=builder --chown=65532:65532 /workspace/data /data
 
 EXPOSE 4920/tcp
 
+USER 65532:65532
+
 VOLUME /data
 
-ENTRYPOINT ["/bitraft"]
+ENTRYPOINT ["/app/bitraft"]
 CMD ["-d", "/data"]


### PR DESCRIPTION
Running images as UID 0 is avoided in Openshift and K8s. I've made changes to the Dockerfile to build a minimal image that complies with security requirements in these platforms.

It's also possible to override the two ARG at the start with docker --build-arg flag if you want to publish images for other architectures.

I did not edit .github/workflows/docker. I will edit another PR with suggestions on that.